### PR TITLE
Fix a typo in Gentx guide

### DIFF
--- a/guides/testnets/turing-3/GENTX.md
+++ b/guides/testnets/turing-3/GENTX.md
@@ -23,7 +23,7 @@
 5. Create an account
 
     ``` sh
-    setinel-hubcli keys add <name>
+    sentinel-hub-cli keys add <name>
     ```
 
 6. Add the account to the genesis


### PR DESCRIPTION
cli binary is `sentinel-hub-cli`not `setinel-hubcli`