### PR TITLE
keys add <name> was missing

### DIFF
--- a/docs/dVPN-node/start.md
+++ b/docs/dVPN-node/start.md
@@ -67,7 +67,7 @@ docker run --rm \
     --interactive \
     --tty \
     --volume ${HOME}/.sentinelnode:/root/.sentinelnode \
-    sentinel-dvpn-node process keys add
+    sentinel-dvpn-node process keys add <yourAccountName>
 ```
 
 Pass flag `--recover` to recover the key with Mnemonic


### PR DESCRIPTION
Otherwise user will get:

 docker run --rm \
>     --interactive \
>     --tty \
>     --volume ${HOME}/.sentinelnode:/root/.sentinelnode \
>     sentinel-dvpn-node process keys add
Error: invalid section keyring: from cannot be empty